### PR TITLE
LocalMaps Patch 2.3.1 Bug Fixes

### DIFF
--- a/src/ElevationProfile/Widget.js
+++ b/src/ElevationProfile/Widget.js
@@ -188,6 +188,7 @@ define([
         this.measureTool.setTool("distance", false);
         domStyle.set(this.lblDrawLine, "display", "none");
         domStyle.set(this.lblSelectLine, "display", "inline");
+        this.measureTool.clearResult();
         
         this.own(this._selectLineListener = on(this.map.infoWindow, 'set-features', lang.hitch(this, function (evt) {
           //evt.stopPropagation();

--- a/src/ElevationProfile/Widget.js
+++ b/src/ElevationProfile/Widget.js
@@ -170,20 +170,26 @@ define([
         this._initMeasureTool();
       },
 
+      _selectLineListener: undefined,
+
       _drawLine: function () {
         domStyle.set(this.lblDrawLine, "display", "inline");
         domStyle.set(this.lblSelectLine, "display", "none");
+        if (this._selectLineListener) {
+          this._selectLineListener.remove();
+          this._selectLineListener = undefined;
+        }
         this.measureTool.setTool("distance", true);
       },
 
-        _selectLine: function () {
-            this.map.setInfoWindowOnClick(false);
-            topic.publish('lm-disable-popup');
+      _selectLine: function () {
+        this.map.setInfoWindowOnClick(false);
+        topic.publish('lm-disable-popup');
         this.measureTool.setTool("distance", false);
         domStyle.set(this.lblDrawLine, "display", "none");
         domStyle.set(this.lblSelectLine, "display", "inline");
-          
-        this.own(on(this.map.infoWindow, 'set-features', lang.hitch(this, function (evt) {
+        
+        this.own(this._selectLineListener = on(this.map.infoWindow, 'set-features', lang.hitch(this, function (evt) {
           //evt.stopPropagation();
           var selectedFeature = evt.target.getSelectedFeature();
           if (selectedFeature.geometry.type === 'polyline') {
@@ -683,6 +689,14 @@ define([
           this.elevationIndicator2 = null;
         }
         this._displayChartLocation(-1);
+        domStyle.set(this.lblSelectLine, "display", "none");
+        domStyle.set(this.lblSelectLine, "display", "none");
+        this.measureTool.setTool("distance", false);
+        if (this._selectLineListener) {
+          this._selectLineListener.remove();
+          this._selectLineListener = undefined;
+        }
+
         this._getProfile(geometry).then(lang.hitch(this, function (elevationInfo) {
           this.elevationInfo = elevationInfo;
           this._updateProfileChart();

--- a/src/ElevationProfile/Widget.js
+++ b/src/ElevationProfile/Widget.js
@@ -538,7 +538,6 @@ define([
             },
             callbackParamName: 'callback'
           }).then(lang.hitch(this, function (taskInfo) {
-            //console.log('GP Service Details: ', taskInfo);
 
             // TASK DETAILS //
             this.taskInfo = taskInfo;
@@ -872,6 +871,16 @@ define([
             this.elevationIndicator2 = new MouseIndicator(this.profileChart, 'default', indicatorProperties2);
             this.elevationIndicator = new MouseIndicator(this.profileChart, 'default', indicatorProperties);
           }
+          // CLEAR RED MARKER CROSS ON CHART MOUSE LEAVE //
+          on(this._chartNode, 'mouseleave', lang.hitch(this, function(){
+            this._displayChartLocation(-1);
+          }));
+          // CLEAR RED MARKER CROSS ON CLICK OUTSIDE CHART //
+          on(document, 'click', lang.hitch(this, function(evt) {
+            if (!this._chartNode.contains(evt.target)) {
+              this._displayChartLocation(-1);
+            }
+          }));
           this.profileChart.fullRender();
         }
 

--- a/src/ElevationProfile/Widget.js
+++ b/src/ElevationProfile/Widget.js
@@ -673,6 +673,16 @@ define([
         html.setStyle(this.divOptions, 'display', 'none');
         html.setStyle(this.btnDownload, 'display', 'none');
         html.setStyle(this.progressBar.domNode, 'display', 'block');
+        // clear/disable interactions while getting new profile geometry
+        if (this.elevationIndicator) {
+          this.elevationIndicator.destroy();
+          this.elevationIndicator = null;
+        }
+        if (this.elevationIndicator2) {
+          this.elevationIndicator2.destroy();
+          this.elevationIndicator2 = null;
+        }
+        this._displayChartLocation(-1);
         this._getProfile(geometry).then(lang.hitch(this, function (elevationInfo) {
           this.elevationInfo = elevationInfo;
           this._updateProfileChart();
@@ -871,11 +881,11 @@ define([
             this.elevationIndicator2 = new MouseIndicator(this.profileChart, 'default', indicatorProperties2);
             this.elevationIndicator = new MouseIndicator(this.profileChart, 'default', indicatorProperties);
           }
-          // CLEAR RED MARKER CROSS ON CHART MOUSE LEAVE //
+          // CLEAR RED X ON CHART MOUSE LEAVE //
           on(this._chartNode, 'mouseleave', lang.hitch(this, function(){
             this._displayChartLocation(-1);
           }));
-          // CLEAR RED MARKER CROSS ON CLICK OUTSIDE CHART //
+          // CLEAR RED X ON CLICK OUTSIDE CHART //
           on(document, 'click', lang.hitch(this, function(evt) {
             if (!this._chartNode.contains(evt.target)) {
               this._displayChartLocation(-1);

--- a/src/ElevationProfile/Widget.js
+++ b/src/ElevationProfile/Widget.js
@@ -104,7 +104,7 @@ define([
         var panel = dom.byId('widgets_ElevationProfile_Widget_38_panel');
         domClass.add(panel, 'jimu-widget-panel-elevation');
 
-        if (has('ipad') || has('iphone') || has('android')) {
+        if (has('touch')) {
           domStyle.set(this.btnFinish, 'display', 'inline-block');
         }
 


### PR DESCRIPTION
Fixes for DevOps issues 285, 287, also bug: measurement remains on screen when line selected, improvement: drawing mode/select mode without controls after first profile graph drawn.
- Red X cleared on mouseout or click/touch away from profile chart
- Red X cleared and interaction disabled from old profile  on submission of new geometry
- Finish drawing button shown on all devices with touch capability (not just iphone/ipad/android)
- Select/Draw mode cleared on submission of geometry
- measurement cleared from screen when mode changed to select new line